### PR TITLE
Radio Silence: numDownstreamPacketsRadioSilenceEnabledDrop

### DIFF
--- a/meta/emanephy.xml
+++ b/meta/emanephy.xml
@@ -18,6 +18,7 @@
       <entry name="numDownstreamPacketsBroadcastGenerated0" type="uint64"/>
       <entry name="numDownstreamPacketsBroadcastRx0" type="uint64"/>
       <entry name="numDownstreamPacketsBroadcastTx0" type="uint64"/>
+      <entry name="numDownstreamPacketsRadioSilenceEnabledDrop" type="uint64"/>
       <entry name="numDownstreamPacketsUnicastDrop0" type="uint64"/>
       <entry name="numDownstreamPacketsUnicastGenerated0" type="uint64"/>
       <entry name="numDownstreamPacketsUnicastRx0" type="uint64"/>


### PR DESCRIPTION
Added entry for numDownstreamPacketsRadioSilenceEnabledDrop statistic in the physical layer, which tracks the number of packets dropped because new physical layer configuration parameter 'radiosilenceenable' is set to 'on'.

Link to Radio Silence [changes](https://github.com/adjacentlink/emane/pull/248/commits/4167b9a48b75f6e53f02c74f48d82bb6f0e599fd) in emane:
